### PR TITLE
feat(fun-mode): add settings panel with persistence; seed planning docs

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,24 @@
+<body>
+    <div class="quiz-container">
+        <div class="title-area">
+             <h1>AlgoQuiz: Blind 75 Practice</h1>
+             <!-- Sponsor Link/Button -->
+             <a href="#sponsor-link-placeholder" id="sponsor-button" class="sponsor-button" target="_blank" rel="noopener noreferrer">
+                 ❤️ Sponsor
+             </a>
+        </div>
+       
+        <!-- Reset Button REMOVED from Here -->
+        <!-- <button id="reset-progress-button">Reset Progress</button> -->
+
+        <!-- Tab Navigation -->
+        <div class="tab-navigation">
+            <button class="tab-button active" data-tab="quiz-content">Quiz</button>
+            <button class="tab-button" data-tab="question-list">Question List</button>
+            <button class="tab-button" data-tab="review">Review</button>
+        </div>
+
+        <!-- ... rest of quiz content ... -->
+
+    </div>
+</body> 

--- a/client/style.css
+++ b/client/style.css
@@ -1,0 +1,48 @@
+.quiz-container {
+    max-width: 900px; /* Slightly wider for desktop */
+    margin: auto;
+    background: #fff;
+    padding: 30px;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+}
+
+.title-area {
+    display: flex;
+    align-items: center; /* Vertically align title and button */
+    justify-content: center; /* Center items */
+    gap: 20px; /* Space between title and button */
+    margin-bottom: 20px;
+    flex-wrap: wrap; /* Allow button to wrap on small screens */
+}
+
+h1 {
+    text-align: center;
+    /* margin-bottom: 20px; Removed margin, handled by title-area */
+    margin: 0; /* Remove default margin */
+    color: #333;
+    font-size: 1.8rem; /* Relative size */
+}
+
+/* Sponsor Button Style */
+.sponsor-button {
+    display: inline-block;
+    padding: 6px 12px;
+    background-color: #f8f9fa; /* Light background */
+    color: #e83e8c; /* Pink/sponsor color */
+    border: 1px solid #e83e8c;
+    border-radius: 5px;
+    text-decoration: none;
+    font-size: 0.85rem;
+    font-weight: bold;
+    transition: background-color 0.2s ease, color 0.2s ease;
+    white-space: nowrap; /* Prevent wrapping */
+}
+
+.sponsor-button:hover {
+    background-color: #e83e8c;
+    color: white;
+}
+
+/* Style for Reset Button inside Question List tab */
+/* ... rest of styles ... */ 

--- a/index.html
+++ b/index.html
@@ -3,74 +3,113 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Coding Quiz</title>
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-okaidia.min.css" rel="stylesheet" />
+    <title>AlgoQuiz</title>
     <link rel="stylesheet" href="style.css">
+    <!-- Link to Prism CSS from CDN -->
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-okaidia.min.css" rel="stylesheet" />
 </head>
 <body>
     <div class="quiz-container">
-        <h1>Coding Interview Quiz</h1>
+        <h1>AlgoQuiz: Blind 75 Practice</h1>
+
+        <div class="settings-panel" role="region" aria-label="Fun Mode settings">
+            <label class="settings-toggle" for="fun-mode-toggle">
+                <input type="checkbox" id="fun-mode-toggle" checked>
+                <span class="toggle-title">Fun Mode</span>
+            </label>
+            <label class="settings-toggle" for="sounds-toggle">
+                <input type="checkbox" id="sounds-toggle">
+                <span class="toggle-title">Sounds</span>
+            </label>
+            <label class="settings-toggle" for="reduced-motion-toggle">
+                <input type="checkbox" id="reduced-motion-toggle">
+                <span class="toggle-title">Reduced Motion</span>
+            </label>
+        </div>
+        
+        <!-- Reset Button REMOVED from Here -->
+        <!-- <button id="reset-progress-button">Reset Progress</button> -->
 
         <!-- Tab Navigation -->
         <div class="tab-navigation">
-            <button class="tab-button active" data-tab="quiz">Quiz</button>
+            <button class="tab-button active" data-tab="quiz-content">Quiz</button>
             <button class="tab-button" data-tab="question-list">Question List</button>
-            <button class="tab-button" data-tab="review">Review Progress</button>
+            <button class="tab-button" data-tab="review">Review</button>
         </div>
 
-        <!-- Quiz Tab Content -->
-        <div class="tab-content active" id="quiz-tab">
-            <!-- Progress Bar Area -->
+        <!-- Quiz Content Area -->
+        <div id="quiz-content" class="tab-content active">
+            <!-- Progress Bar -->
             <div class="progress-container">
-                <div id="progress-text"></div>
+                <div id="progress-text">Question 1/X</div>
                 <div class="progress-bar-container">
                     <div id="progress-bar-fill"></div>
                 </div>
             </div>
-            <!-- End Progress Bar Area -->
 
-            <div id="question-area">
-                <h2 id="problem-title"></h2>
-                <div id="problem-statement"></div>
-                <pre><code id="code-skeleton" class="language-python"></code></pre>
-                <p><strong># TODO: Choose the correct implementation below</strong></p>
+            <!-- Main Quiz Area (Now Flex/Grid Container) -->
+            <div id="question-area" class="quiz-layout">
+                <!-- Left Panel -->
+                <div id="left-panel">
+                    <div id="problem-statement">
+                        <!-- Problem statement will be loaded here -->
+                    </div>
+                    <pre id="code-skeleton"><code class="language-python">
+                        # Code skeleton will appear here
+                    </code></pre>
+                </div>
+
+                <!-- Right Panel -->
+                <div id="right-panel">
+                    <div id="choice-tabs">
+                        <!-- Choice tabs will be dynamically generated here -->
+                    </div>
+                    <div id="choice-details">
+                        <!-- Selected choice code snippet will appear here -->
+                        <div id="choices-placeholder">Select an answer tab above to see the code.</div>
+                    </div>
+                    <!-- Radio buttons might be hidden or integrated differently -->
+                    <form id="choices-area" style="display: none;"> <!-- Keep form for logic but hide visually -->
+                        <!-- Choices will be loaded here (hidden inputs?) -->
+                    </form>
+
+                    <!-- Moved Controls and Feedback Inside Right Panel -->
+                    <div id="feedback-area" style="display: none; margin-top: 15px;"></div>
+                    <div class="button-group" style="margin-top: auto; padding-top: 15px;">
+                        <button id="check-button">Check Answer</button>
+                        <button id="next-button" style="display: none;">Next Question</button>
+                    </div>
+                </div>
             </div>
 
-            <div id="choices-area">
-                <!-- Choices will be populated by JavaScript -->
-            </div>
-
-            <button id="check-button">Check Answer</button>
-
-            <div id="feedback-area">
-                <!-- Feedback Correct/Incorrect will appear here -->
-            </div>
-            <button id="next-button" style="display: none;">Next Question</button>
         </div>
 
-        <!-- Question List Tab Content -->
-        <div class="tab-content" id="question-list-tab">
+        <!-- Question List Area -->
+        <div id="question-list" class="tab-content">
+            <h2>Question List</h2>
             <div id="questions-list">
-                <!-- Questions list will be populated by JavaScript -->
+                <!-- Dynamically populated list -->
             </div>
-        </div>
-
-        <!-- Review Tab Content -->
-        <div class="tab-content" id="review-tab">
-            <h2>Session Review</h2>
-            <div id="review-summary">
-                <!-- Summary stats will go here -->
-            </div>
-            <ul id="review-list">
-                <!-- Review items will be populated here -->
-            </ul>
+            <!-- Moved Reset Button Back Here -->
             <button id="reset-progress-button">Reset Progress</button>
         </div>
 
+        <!-- Review Area -->
+        <div id="review" class="tab-content">
+            <h2>Review Incorrect Answers</h2>
+            <div id="review-summary">
+                <!-- Summary stats will be added here -->
+            </div>
+            <ul id="review-list">
+                <!-- Incorrect answers will be listed here -->
+            </ul>
+        </div>
     </div>
 
+    <!-- Link to Prism JS from CDN -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
-    <script src="quiz.js"></script>
+    <!-- Link to Quiz Logic -->
+    <script src="quiz.js" defer></script>
 </body>
 </html>

--- a/planning/README.md
+++ b/planning/README.md
@@ -1,0 +1,3 @@
+﻿# Planning Docs
+
+Use this folder to track tasks, milestones, and status for the Fun Mode rollout.

--- a/planning/feature-breakdown.md
+++ b/planning/feature-breakdown.md
@@ -1,0 +1,28 @@
+﻿# Fun Mode Feature Breakdown
+
+## Milestones
+1. **Settings & User State**
+   - Fun Mode / Focus Mode toggle UI
+   - Sound & motion preferences
+   - Persist user configuration (lgoQuizUserState)
+2. **Streak & XP Layer**
+   - Track session streak and best streak
+   - XP computation (base, streak bonus, hint penalty)
+   - UI badges/progress indicators
+3. **Hints System**
+   - 50/50 and rationale fragment flows
+   - Penalty hooks (XP, streak suppression)
+   - Copy and tooltip guidance
+4. **Session Summary & Review Enhancements**
+   - Summary card with XP, streaks, hint usage
+   - Retry-missed CTA and stats integration
+
+## Dependencies
+- Extended question schema (quiz-data.json)
+- Prism highlighting for dynamic hint code blocks
+- LocalStorage availability
+
+## Risks
+- LocalStorage quota & serialization errors
+- Animation performance on low-power devices
+- Ensuring default behavior when Fun Mode disabled

--- a/planning/task-backlog.md
+++ b/planning/task-backlog.md
@@ -1,0 +1,19 @@
+﻿# Task Backlog
+
+## Ready
+- [ ] Add lgoQuizUserState load/save helpers in quiz.js
+- [ ] Render Fun Mode / Focus Mode toggle + sound + reduced motion switches
+- [ ] Build session streak tracker (logic + UI badge)
+- [ ] Compute XP + level metrics and render progress bar
+- [ ] Implement hint buttons (50/50, rationale)
+- [ ] Hook hint penalties into scoring logic
+- [ ] Create session summary modal/card with stats
+- [ ] Update review tab to display XP and hint data
+- [ ] Extend quiz-data.json with optional metadata fields
+
+## In Progress
+- [ ] Planning scaffolding and initial structure
+
+## Done
+- [x] Capture updated PRD requirements
+- [x] Set up planning docs folder

--- a/prd.md
+++ b/prd.md
@@ -1,34 +1,31 @@
-# Product Requirements Document: AlgoQuiz (Blind 75 MVP)
+# Product Requirements Document: AlgoQuiz (Blind 75 MVP + Fun Mode)
 
 ## 1. Introduction
-
 AlgoQuiz is an interactive, Duolingo-inspired web application designed to help software engineering students and professionals prepare for technical interviews by practicing LeetCode-style coding problems. It focuses on the Blind 75 list of common interview questions. The core experience involves presenting a problem statement and a partial Python code solution, requiring the user to select the correct code snippet from multiple choices to complete it, providing immediate feedback and explanations.
 
 ## 2. Goals
-
 *   **Primary Goal:** Provide an engaging and effective platform for learning and reinforcing Data Structures & Algorithms (DS&A) concepts relevant to technical interviews.
 *   **MVP Goal:** Launch a functional quiz application covering a significant portion of the Blind 75 questions, focusing on the core "choose the correct code snippet" interaction with immediate feedback and explanations.
 *   **User Goal:** Help users efficiently practice common algorithm problems, identify knowledge gaps, and learn from mistakes through clear explanations.
 *   **Learning Goal:** Solidify understanding of different approaches (e.g., brute force vs. optimal) and common pitfalls for standard algorithm problems.
+*   **Fun Mode Goal (New):** Add optional Duolingo-style gamification (session streaks, simple XP/levels, subtle animations, optional sounds) to increase motivation without distracting from learning.
 
 ## 3. Target Audience
-
 *   Software engineering students preparing for internships or full-time roles.
 *   Professional developers preparing for job changes or upskilling in algorithms.
 *   Individuals seeking an interactive alternative to traditional LeetCode grinding or video tutorials.
+*   Learners who respond well to gamified progress indicators and bite-sized practice loops.
 
 ## 4. User Stories
-
 *   **As a student preparing for interviews, I want to** quickly test my understanding of common Blind 75 problems **so that I can** identify areas I need to study more.
 *   **As a developer, I want to** see different implementation choices for a problem, including incorrect ones, **so that I can** better understand common mistakes and edge cases.
 *   **As a user, I want to** receive immediate feedback on my answers **so that I can** quickly learn if my understanding is correct.
 *   **As a user, I want to** read explanations for why an answer is correct or incorrect **so that I can** solidify my learning.
-*   **As a user, I want to** track my progress through the quiz **so that I can** see how much I've completed.
+*   **As a user, I want to** track my progress through the quiz **so that I can** see how much I have completed.
 *   **As a user, I want to** navigate between the quiz and a list of all questions **so that I can** jump to specific problems if needed.
-*   **As a user, I want to** see the code presented clearly with syntax highlighting **so that it is** easy to read and understand.
+*   **As a motivated learner, I want to** build streaks, earn XP, and celebrate milestones **so that I can** stay engaged during longer practice sessions.
 
 ## 5. Features (MVP Detailed Breakdown)
-
 *   **5.1. Quiz Interface:**
     *   Display Problem Title.
     *   Display Problem Statement (formatted text, including examples and constraints).
@@ -46,7 +43,7 @@ AlgoQuiz is an interactive, Duolingo-inspired web application designed to help s
         *   Indicate "Correct" or "Incorrect".
         *   Highlight the user's selected choice (e.g., green border if correct, red if incorrect).
         *   Highlight the correct choice if the user selected an incorrect one.
-    *   Display explanations for *why* the selected choice was correct/incorrect. (Potentially show explanations for all choices after submission).
+    *   Display explanations for why the selected choice was correct/incorrect. (Potentially show explanations for all choices after submission).
     *   Disable choice selection and "Check Answer" button after submission for the current question.
 *   **5.4. Navigation:**
     *   "Next Question" button appears after checking an answer, loads the subsequent question.
@@ -62,7 +59,7 @@ AlgoQuiz is an interactive, Duolingo-inspired web application designed to help s
 *   **5.7. Question List View:**
     *   Display a list of all available question titles in the "Question List" tab.
     *   Allow users to click a question title to jump directly to that question in the quiz view.
-    *   Visually indicate which questions have been answered (using ✅/❌ icons) based on saved session progress.
+    *   Visually indicate which questions have been answered using clear textual prefixes (e.g., "[Done]", "[Missed]") based on saved session progress.
 *   **5.8. Session Persistence & Review:** (New Feature)
     *   User progress (which questions answered, selected choice, correctness) is saved to `localStorage` after each answer.
     *   On page load, the application checks `localStorage` for saved progress and resumes the quiz at the next unanswered question.
@@ -70,52 +67,90 @@ AlgoQuiz is an interactive, Duolingo-inspired web application designed to help s
     *   The Review tab displays summary statistics: Total Answered, Correct, Incorrect, Score %.
     *   The Review tab lists all answered questions, showing the title, correct/incorrect status, the user's selected answer (truncated), and the correct answer (truncated, if incorrect).
     *   A "Reset Progress" button in the Review tab allows clearing the saved session data and starting fresh (with confirmation).
+*   **5.9. Fun & Gamification (MVP-Fun):**
+    *   **Fun Mode Toggle / Focus Mode:** Fun Mode ON by default; Focus Mode reduces animations and disables sounds for a calmer experience.
+    *   **Session Streak:** Flame-style indicator showing consecutive correct answers in the current session. An incorrect answer breaks the streak. Using a hint prevents the streak from increasing on that question.
+    *   **XP & Levels:** Base +10 XP per correct answer; streak bonus +2 XP per tier (every three correct answers in a row, capped at +6 XP); -5 XP penalty whenever a hint is used; linear level curve where level N requires N x 100 cumulative XP. Session summary shows XP gained and progress toward the next level.
+    *   **Hints (No Coins):** Offer a 50/50 option (remove two incorrect choices when applicable) and a short rationale fragment that nudges the learner toward the optimal approach. Hints apply the XP penalty and disable streak growth for that question; they also reduce the session score shown in the summary.
+    *   **Celebrations & Micro-Interactions:** Subtle confetti bursts and button micro-animations on correct answers and streak milestones (three, six, nine in a row). Optional short sounds accompany events; sounds are disabled by default.
+    *   **Session Summary:** After a session or when the user opts to finish, present questions attempted, correct/incorrect counts, best streak, XP gained, level progress, hint usage, and a quick action to retry missed questions.
 
 ## 6. Design & UX Requirements
-
 *   **Visual Style:** Clean, intuitive interface. Inspiration drawn from Duolingo's feedback style (clear correct/incorrect states, progress tracking). Use the Okaidia theme for Prism.js.
 *   **Layout:** Responsive design, usable on typical desktop/laptop screen sizes. Max-width container for readability.
 *   **Readability:** Ensure problem statements and code are easily readable (adequate font size, line spacing, syntax highlighting).
 *   **Feedback:** Feedback must be immediate, clear, and informative. Explanations are crucial for the learning aspect.
 *   **Interaction:** Simple and intuitive controls (radio buttons, clear buttons). Smooth transitions for progress bar updates.
+*   **Fun and Focus Modes:** Provide easy access to toggle fun features on/off. Respect browser `prefers-reduced-motion` settings and Focus Mode when rendering animations.
+*   **Animations:** Keep animations short, subtle, and non-blocking. Avoid overwhelming the learner.
+*   **Audio:** Optional short cues for correct/incorrect answers. Sounds are muted by default and can be enabled via settings.
 
 ## 7. Technical Requirements
-
-*   **Frontend:** Vanilla JavaScript (ES6+), HTML5, CSS3. No external frameworks (React, Vue, Angular) for the MVP.
-*   **Libraries:** Prism.js for syntax highlighting.
-*   **Data:** Question data loaded from an external `quiz-data.json`.
+*   **Frontend:** Vanilla JavaScript (ES6+), HTML5, CSS3.
+*   **Libraries:** Prism.js for syntax highlighting; small client-only effect libraries (e.g., lightweight confetti) are permitted if they keep bundle size reasonable.
+*   **Data:** Question data loaded from an external `quiz-data.json` (schema may be extended as outlined below).
 *   **Compatibility:** Target modern web browsers (latest Chrome, Firefox, Safari, Edge).
 *   **Deployment:** Static site hosting (e.g., GitHub Pages, Netlify, Vercel). No backend server required.
 *   **Code Quality:** Adhere to rules defined in `.cursorrules` (consistent style, JSDoc for non-trivial functions, etc.). Recent refactoring in `quiz.js` has improved event handling and state management related to question lists and navigation.
 
-## 8. Non-Goals (MVP)
+### 7.1 Data Schema Extensions (JSON)
+Add optional fields to each question (backward compatible when omitted):
+```jsonc
+{
+  "id": "two-sum",
+  "difficulty": "Easy",
+  "topics": ["Array", "HashMap"],
+  "xpReward": 12,
+  "hints": {
+    "rationale": "Consider trading space for time with an auxiliary map.",
+    "hasFiftyFifty": true
+  }
+}
+```
 
-*   User accounts or *cross-device* persistent progress tracking (uses `localStorage` only).
-*   Saving quiz state *mid-question* if the browser is closed.
+### 7.2 LocalStorage State
+*   `algoQuizProgress`: Existing per-question completion state.
+*   `algoQuizUserState` (new): `{ "xp": number, "level": number, "sessionStreak": number, "bestSessionStreak": number, "settings": { "funMode": true, "sounds": false, "reducedMotion": false } }`.
+
+## 8. Non-Goals (MVP)
+*   User accounts or cross-device persistent progress tracking (uses `localStorage` only).
+*   Saving quiz state mid-question if the browser is closed.
 *   Support for languages other than Python for solutions.
 *   Allowing users to type code instead of multiple choice.
-*   Advanced analytics or performance tracking.
+*   Advanced analytics or external performance tracking.
 *   Integration with LeetCode accounts.
 *   Timer per question or per quiz.
 *   Mobile-specific optimization (focus on desktop/laptop first).
 *   Loading questions from a backend or external API.
+*   Coins, stores, or premium power-ups.
+*   Daily streaks or online leaderboards (session streak only in MVP-Fun).
 
 ## 9. Success Metrics
-
-*   **Completion Rate:** Percentage of users who start a quiz session and complete all questions.
-*   **Feature Adoption:** Usage of the "Question List" tab.
-*   **Content Coverage:** Number of Blind 75 questions successfully implemented with high-quality choices and explanations.
-*   **Qualitative Feedback:** User feedback gathered through usability testing or surveys (post-MVP).
+*   **Session Length (Primary):** Average time-on-site per session, targeting a 20-30% lift when Fun Mode is active.
+*   **Completion Rate:** Percentage of users who complete the current session's selected set.
+*   **Streak Engagement:** Average best streak per session and hint usage rate.
+*   **Feature Adoption:** Fun Mode toggle usage, hint usage, and "Retry missed" activation from the review summary.
+*   **Content Coverage:** Number of Blind 75 questions implemented with high-quality choices and explanations.
+*   **Qualitative Feedback:** User perception of motivation and enjoyment without feeling distracted.
 
 ## 10. Future Considerations (Post-MVP Roadmap)
+*   Refactor `quizData` (done) to maintain questions externally.
+*   Complete Blind 75 content.
+*   Enhance explanations with richer formatting and optional resource links.
+*   Review 2.0: spaced repetition (local-only) and targeted "retry missed" sets.
+*   Topic and difficulty filtering with lightweight adaptive recommendations based on recent misses/correct answers.
+*   Daily/weekly challenges with local best streak tracking.
+*   Achievements and badges for streak lengths, topic mastery, and speed milestones.
+*   User accounts and cross-device sync (post frontend-only phase).
+*   Support for additional programming languages (Java, C++, JavaScript).
+*   Accessibility improvements: ARIA roles, full keyboard navigation parity, expanded reduced-motion support.
+*   Mobile optimization for smaller screens.
 
-*   **Refactor `quizData`:** (Done) Question data is now loaded from an external JSON file for better maintainability and scalability.
-*   **Complete Content:** Add all remaining Blind 75 questions.
-*   **Enhance Explanations:** Improve display format, potentially add links to external resources or LeetCode discussions.
-*   **Review Mode:** Allow users to review all questions and their answers/explanations after completing a quiz.
-*   **Topic Filtering:** Allow users to select specific DS&A categories (Arrays, Trees, DP, etc.) for focused quizzes.
-*   **Persistence:** Use `localStorage` to save progress within a session or potentially across sessions.
-*   **User Accounts:** Basic user accounts to track long-term progress and performance.
-*   **More Languages:** Support for other popular interview languages (e.g., Java, C++, JavaScript).
-*   **Accessibility Improvements:** Conduct thorough accessibility audit and implement necessary ARIA attributes and keyboard navigation enhancements.
-*   **Mobile Optimization:** Improve layout and usability on smaller screens.
+## 11. Implementation Notes (MVP-Fun)
+*   Add Fun Mode/Focus Mode toggle and settings UI (sounds default OFF).
+*   Implement session streak tracking and UI; ensure hints suppress streak growth for that question.
+*   Track XP and levels in `algoQuizUserState`; apply streak bonuses and hint penalties; display level progress bar.
+*   Implement hints (50/50 and rationale fragment) with clear copy explaining penalties.
+*   Add subtle confetti and micro-animations while honoring Focus Mode and reduced-motion settings.
+*   Add a session summary card showing XP, level progress, best streak, hint usage, and quick access to retry missed questions.
+*   Extend `quiz-data.json` incrementally with new fields; default gracefully when data is absent.

--- a/quiz-data.json
+++ b/quiz-data.json
@@ -1288,5 +1288,32 @@
         "explanation": "This `startsWith` implementation is incorrect because it checks `isEndOfWord` at the end of the prefix traversal. It should return true simply if the prefix path exists in the trie, regardless of whether that prefix itself forms a complete word."
       }
     ]
+  },
+  {
+    "problemTitle": "143. Reorder List",
+    "problemStatement": "You are given the head of a singly linked-list. The list can be represented as:\nL0 → L1 → … → Ln - 1 → Ln\n\nReorder the list to be on the following form:\nL0 → Ln → L1 → Ln - 1 → L2 → Ln - 2 → …\n\nYou may not modify the values in the list's nodes. Only nodes themselves may be changed.\n\nExample 1:\nInput: head = [1,2,3,4]\nOutput: [1,4,2,3]\n\nExample 2:\nInput: head = [1,2,3,4,5]\nOutput: [1,5,2,4,3]\n\nConstraints:\nThe number of nodes in the list is in the range [1, 5 * 10^4].\n1 <= Node.val <= 1000",
+    "codeSkeleton": "# Definition for singly-linked list.\n# class ListNode:\n#     def __init__(self, val=0, next=None):\n#         self.val = val\n#         self.next = next\nclass Solution:\n    def reorderList(self, head: ListNode) -> None:\n        \"\"\"\n        Do not return anything, modify head in-place instead.\n        \"\"\"\n        # <MISSING CODE BLOCK>",
+    "choices": [
+      {
+        "text": "# Store nodes in an array and reorder using two pointers\nnodes = []\n\n# Store all nodes in an array\ncurr = head\nwhile curr:\n    nodes.append(curr)\n    curr = curr.next\n\nleft, right = 0, len(nodes) - 1\n\n# Reorder the list by connecting nodes from outside in\nwhile left < right:\n    # Connect left to right\n    nodes[left].next = nodes[right]\n    left += 1\n    \n    # Break if pointers meet or cross\n    if left >= right:\n        break\n    \n    # Connect right to new left\n    nodes[right].next = nodes[left]\n    right -= 1\n\n# Make sure the last node points to None\nnodes[left].next = None",
+        "correct": true,
+        "explanation": "This approach correctly reorders the list by first storing all nodes in an array, then using two pointers (left and right) to relink the nodes in the required order. It preserves the original nodes and only changes their connections, as required by the problem. Time complexity is O(n), and space complexity is O(n) for the array."
+      },
+      {
+        "text": "# Find middle, reverse second half, and merge two lists\nif not head or not head.next:\n    return\n\n# Find the middle of the linked list\nslow, fast = head, head\nwhile fast and fast.next:\n    slow = slow.next\n    fast = fast.next.next\n\n# Reverse the second half\nprev, curr = None, slow\nwhile curr:\n    next_temp = curr.next\n    curr.next = prev\n    prev = curr\n    curr = next_temp\n\n# Merge the first half with reversed second half\nfirst, second = head, prev\nwhile second.next:\n    temp1, temp2 = first.next, second.next\n    first.next = second\n    second.next = temp1\n    first, second = temp1, temp2",
+        "correct": false,
+        "explanation": "This approach uses O(1) extra space by: 1) finding the middle of the list, 2) reversing the second half, and 3) merging the first half with the reversed second half. While correct, it's more complex than the array-based solution and easier to make mistakes in implementation."
+      },
+      {
+        "text": "# Incorrect: Only modifies values instead of reordering nodes\nvalues = []\n\n# Store all values\ncurr = head\nwhile curr:\n    values.append(curr.val)\n    curr = curr.next\n\n# Reorder values\nreordered = []\nfor i in range(len(values) // 2):\n    reordered.append(values[i])\n    reordered.append(values[len(values) - 1 - i])\n\n# Add middle element for odd length lists\nif len(values) % 2 == 1:\n    reordered.append(values[len(values) // 2])\n\n# Update list values\ncurr = head\nfor val in reordered:\n    curr.val = val\n    curr = curr.next",
+        "correct": false,
+        "explanation": "This solution incorrectly modifies the values of the nodes instead of changing the node connections. The problem specifically states 'You may not modify the values in the list's nodes. Only nodes themselves may be changed.'"
+      },
+      {
+        "text": "# Incorrect: Combines nodes incorrectly\nnodes = []\n\n# Store all nodes\ncurr = head\nwhile curr:\n    nodes.append(curr)\n    curr = curr.next\n\n# Incorrectly relinks nodes\nfor i in range(len(nodes) // 2):\n    # Error: Incorrect linking pattern\n    nodes[i].next = nodes[len(nodes) - 1 - i]\n    # Error: This creates cycles and doesn't follow the pattern\n    if i < len(nodes) // 2 - 1:\n        nodes[len(nodes) - 1 - i].next = nodes[i + 1]\n\n# Error: Doesn't properly handle list end\nif len(nodes) % 2 == 0:\n    nodes[len(nodes) // 2 - 1].next = None\nelse:\n    nodes[len(nodes) // 2].next = None",
+        "correct": false,
+        "explanation": "This solution incorrectly relinks the nodes, creating cycles and not following the required reordering pattern. It doesn't properly connect consecutive nodes from opposite ends and has errors in handling the end of the list."
+      }
+    ]
   }
 ]

--- a/quiz.js
+++ b/quiz.js
@@ -1,515 +1,562 @@
-// --- Quiz Logic ---
-const problemTitleEl = document.getElementById('problem-title');
-const problemStatementEl = document.getElementById('problem-statement');
-const codeSkeletonEl = document.getElementById('code-skeleton'); // The <code> element
-const choicesAreaEl = document.getElementById('choices-area');
-const checkButton = document.getElementById('check-button');
-const feedbackAreaEl = document.getElementById('feedback-area');
-const nextButton = document.getElementById('next-button');
-// --- Add Progress Bar Element References ---
-const progressBarFillEl = document.getElementById('progress-bar-fill');
-const progressTextEl = document.getElementById('progress-text');
-const reviewSummaryEl = document.getElementById('review-summary');
-const reviewListEl = document.getElementById('review-list');
-const resetProgressButton = document.getElementById('reset-progress-button');
+'use strict';
 
-let quizData = [];
 let currentQuestionIndex = 0;
-let correctAnswerIndex = -1;
-let sessionProgress = {}; // { questionIndex: { selected: shuffledIndex, correct: correctAnswerIndex, isCorrect: bool } }
-const SESSION_STORAGE_KEY = 'algoQuizSessionProgress'; // Key for localStorage
+let quizData = []; // Will be populated by fetch
+let selectedAnswerIndex = null; // Track selected answer index
+let quizProgress = {}; // Store progress { questionIndex: { completed: bool, correct: bool, selected: int, explanation: str } }
 
-// --- Persistence Functions ---
-
-/**
- * Saves the current session progress to localStorage.
- */
-function saveSessionProgress() {
-  try {
-    localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(sessionProgress));
-  } catch (e) {
-    console.error("Failed to save session progress:", e);
-  }
-}
-
-/**
- * Loads session progress from localStorage.
- */
-function loadSessionProgress() {
-  try {
-    const savedProgress = localStorage.getItem(SESSION_STORAGE_KEY);
-    if (savedProgress) {
-      sessionProgress = JSON.parse(savedProgress);
-      // Find the next unanswered question to resume
-      const lastAnsweredIndex = Math.max(...Object.keys(sessionProgress).map(Number));
-      // Decide where to start: next question or beginning if all answered
-      if (lastAnsweredIndex >= 0 && lastAnsweredIndex < quizData.length - 1) {
-           currentQuestionIndex = lastAnsweredIndex + 1;
-      } else if (Object.keys(sessionProgress).length === quizData.length) {
-          // All questions answered - maybe start at review or first question?
-          console.log("Quiz previously completed. Starting from beginning or review tab.");
-          // For now, let's just start at 0, Review tab would be better later.
-          currentQuestionIndex = 0; // Or handle differently (e.g., show review tab first)
-      } else {
-          currentQuestionIndex = 0; // Default to start if progress is weird
-      }
-      console.log("Session progress loaded. Resuming at question:", currentQuestionIndex + 1);
-    } else {
-      sessionProgress = {};
-      currentQuestionIndex = 0; // No saved progress
+// User state (Fun Mode, sounds, motion, XP, streaks)
+const defaultUserState = {
+    xp: 0,
+    level: 1,
+    sessionStreak: 0,
+    bestSessionStreak: 0,
+    settings: {
+        funMode: true,
+        sounds: false,
+        reducedMotion: false,
+        resumePreferences: null
     }
-  } catch (e) {
-    console.error("Failed to load or parse session progress:", e);
-    sessionProgress = {}; // Reset on error
-    currentQuestionIndex = 0;
-  }
-}
+};
 
-// Fetch quiz data from external JSON file
-function fetchQuizData() {
-  fetch('quiz-data.json')
-    .then(response => {
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-      return response.json();
-    })
-    .then(data => {
-      quizData = data;
-      if (quizData.length > 0) {
-         loadSessionProgress(); // Load progress AFTER quiz data is available
-         updateProgressBar();
-         loadQuestion(currentQuestionIndex);
-      } else {
-          console.error("Quiz data is empty.");
-          // Display an error message in the UI
-          document.querySelector('.quiz-container').innerHTML = '<div class="error-message">No questions found in quiz data.</div>';
-      }
-    })
-    .catch(error => {
-      console.error('Error loading or parsing quiz data:', error);
-      document.querySelector('.quiz-container').innerHTML = `<div class="error-message">Failed to load quiz data: ${error.message}. Please refresh.</div>`;
-    });
-}
+let userState = null;
 
-// Add new variables for tab functionality
-const tabButtons = document.querySelectorAll('.tab-button');
+// DOM Elements
+const problemStatementEl = document.getElementById('problem-statement');
+const codeSkeletonEl = document.getElementById('code-skeleton').querySelector('code');
+const choiceTabsEl = document.getElementById('choice-tabs');
+const choiceDetailsEl = document.getElementById('choice-details');
+const choicesPlaceholderEl = document.getElementById('choices-placeholder'); // Placeholder text
+const checkButton = document.getElementById('check-button');
+const nextButton = document.getElementById('next-button');
+const feedbackAreaEl = document.getElementById('feedback-area');
+const progressTextEl = document.getElementById('progress-text');
+const progressBarFillEl = document.getElementById('progress-bar-fill');
+const tabs = document.querySelectorAll('.tab-button');
 const tabContents = document.querySelectorAll('.tab-content');
 const questionsListEl = document.getElementById('questions-list');
+const reviewListEl = document.getElementById('review-list');
+const reviewSummaryEl = document.getElementById('review-summary');
+const resetProgressButton = document.getElementById('reset-progress-button');
+const funModeToggle = document.getElementById('fun-mode-toggle');
+const soundsToggle = document.getElementById('sounds-toggle');
+const reducedMotionToggle = document.getElementById('reduced-motion-toggle');
 
-// Tab switching functionality
-function switchTab(tabId) {
-    console.log(`Switching to tab: ${tabId}`); // Log which tab we're trying to switch to
-
-    // Hide all tab content
-    document.querySelectorAll('.tab-content').forEach(content => {
-        console.log(` Hiding content: #${content.id}`);
-        content.classList.remove('active');
-    });
-
-    // Deactivate all tab buttons
-    document.querySelectorAll('.tab-button').forEach(button => {
-        button.classList.remove('active');
-    });
-
-    // Show the selected tab content
-    const contentToShow = document.getElementById(`${tabId}-tab`);
-    if (contentToShow) {
-        console.log(` Showing content: #${contentToShow.id}`);
-        contentToShow.classList.add('active');
-    } else {
-        console.error(`Content element not found for tab ID: ${tabId}-tab`);
-    }
-
-    // Activate the selected tab button
-    const buttonToActivate = document.querySelector(`.tab-button[data-tab="${tabId}"]`);
-    if (buttonToActivate) {
-        console.log(` Activating button: [data-tab="${buttonToActivate.dataset.tab}"]`);
-        buttonToActivate.classList.add('active');
-    } else {
-        console.error(`Button element not found for data-tab: ${tabId}`);
-    }
-
-    // Populate list ONLY when switching TO that tab
-    if (tabId === 'question-list' && quizData.length > 0) {
-        populateQuestionsList();
-    } else if (tabId === 'review') {
-        populateReviewView();
-    }
-}
-
-// REMOVED loadQuestion override
-
-// --- Progress Bar Logic ---
-function updateProgressBar() {
-    // Ensure quizData is loaded before calculating
-    if (!quizData || quizData.length === 0) {
-        progressBarFillEl.style.width = '0%';
-        progressTextEl.textContent = 'Loading...';
-        return;
-    }
-    const totalQuestions = quizData.length;
-    // Ensure index is valid
-    const displayIndex = Math.max(0, Math.min(currentQuestionIndex, totalQuestions - 1));
-    const percentComplete = ((displayIndex + 1) / totalQuestions) * 100;
-    progressBarFillEl.style.width = `${percentComplete}%`;
-    progressTextEl.textContent = `Question ${displayIndex + 1} of ${totalQuestions}`;
-}
-
-function loadQuestion(questionIndex) {
-     if (questionIndex < 0 || questionIndex >= quizData.length) {
-        console.error("Attempted to load question index out of bounds:", questionIndex);
-        // Optionally handle this case, e.g., show quiz end screen or first question
-        return;
-    }
-
-    const question = quizData[questionIndex];
-
-    // --- Update progress bar for the new question ---
-    updateProgressBar(); // Call this at the beginning of loading
-
-    problemTitleEl.textContent = question.problemTitle;
-    problemStatementEl.innerHTML = ''; // Clear previous
-    // Basic conversion of newline to <br> for problem statement display
-    const statementLines = question.problemStatement.split('\n');
-    statementLines.forEach((line, index) => {
-        problemStatementEl.appendChild(document.createTextNode(line));
-        if (index < statementLines.length - 1) {
-             problemStatementEl.appendChild(document.createElement('br'));
+// --- User State & Settings ---
+function createDefaultUserState() {
+    const prefersReducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    return {
+        xp: defaultUserState.xp,
+        level: defaultUserState.level,
+        sessionStreak: defaultUserState.sessionStreak,
+        bestSessionStreak: defaultUserState.bestSessionStreak,
+        settings: {
+            funMode: defaultUserState.settings.funMode,
+            sounds: defaultUserState.settings.sounds,
+            reducedMotion: prefersReducedMotion || defaultUserState.settings.reducedMotion,
+            resumePreferences: null
         }
-    });
+    };
+}
 
-    codeSkeletonEl.textContent = question.codeSkeleton;
+function loadUserState() {
+    const fallback = createDefaultUserState();
+    try {
+        const stored = localStorage.getItem('algoQuizUserState');
+        if (!stored) {
+            userState = fallback;
+            return;
+        }
+        const parsed = JSON.parse(stored);
+        userState = {
+            ...fallback,
+            ...parsed,
+            settings: {
+                ...fallback.settings,
+                ...(parsed.settings || {})
+            }
+        };
+    } catch (error) {
+        console.warn('Failed to load user state. Using defaults.', error);
+        userState = fallback;
+    }
+}
 
-    // Highlight the main skeleton
-    if (window.Prism) {
-        Prism.highlightElement(codeSkeletonEl);
+function saveUserState() {
+    try {
+        localStorage.setItem('algoQuizUserState', JSON.stringify(userState));
+    } catch (error) {
+        console.warn('Failed to save user state.', error);
+    }
+}
+
+function setToggleDisabledClass(toggleEl) {
+    if (!toggleEl) return;
+    const label = toggleEl.closest('.settings-toggle');
+    if (!label) return;
+    if (toggleEl.disabled) {
+        label.classList.add('settings-toggle--disabled');
     } else {
-        console.warn("Prism syntax highlighter not found.");
+        label.classList.remove('settings-toggle--disabled');
+    }
+}
+
+function applyUserSettings() {
+    if (!userState) return;
+
+    const funModeActive = !!userState.settings.funMode;
+
+    if (funModeToggle) {
+        funModeToggle.checked = funModeActive;
     }
 
-    // Clear previous choices and feedback & reset buttons
-    choicesAreaEl.innerHTML = '';
-    resetFeedbackAndButtons(); // Use helper
+    if (soundsToggle) {
+        if (funModeActive) {
+            soundsToggle.disabled = false;
+            soundsToggle.checked = !!userState.settings.sounds;
+        } else {
+            soundsToggle.disabled = true;
+            soundsToggle.checked = false;
+            userState.settings.sounds = false;
+        }
+        setToggleDisabledClass(soundsToggle);
+    }
 
-    // --- Shuffle choices --- (Keep if desired)
-    let choicesWithOriginalIndex = question.choices.map((choice, index) => ({ choice, originalIndex: index }));
-    let shuffledChoicesWithOriginalIndex = choicesWithOriginalIndex.sort(() => Math.random() - 0.5);
-    correctAnswerIndex = shuffledChoicesWithOriginalIndex.findIndex(item => item.choice.correct);
-    // --- End shuffle ---
+    if (reducedMotionToggle) {
+        if (funModeActive) {
+            reducedMotionToggle.disabled = false;
+            reducedMotionToggle.checked = !!userState.settings.reducedMotion;
+        } else {
+            reducedMotionToggle.disabled = true;
+            reducedMotionToggle.checked = true;
+            userState.settings.reducedMotion = true;
+        }
+        setToggleDisabledClass(reducedMotionToggle);
+    }
 
-    // --- Create and append elements first ---
-    const choiceElementsToHighlight = [];
+    document.body.classList.toggle('fun-mode-off', !funModeActive);
+    document.body.classList.toggle('fun-mode-on', funModeActive);
+    document.body.classList.toggle('sounds-enabled', funModeActive && !!userState.settings.sounds);
+    document.body.classList.toggle('reduced-motion', !funModeActive || !!userState.settings.reducedMotion);
+}
 
-    shuffledChoicesWithOriginalIndex.forEach((item, shuffledIndex) => {
-        const choiceId = `choice-${shuffledIndex}`;
-        const choiceData = item.choice;
+function initializeSettingsPanel() {
+    if (!userState) {
+        loadUserState();
+    }
 
-        const label = document.createElement('label');
-        label.htmlFor = choiceId;
-        label.className = 'choice-label';
-
-        const radio = document.createElement('input');
-        radio.type = 'radio';
-        radio.id = choiceId;
-        radio.name = 'answer';
-        radio.value = shuffledIndex;
-
-        const pre = document.createElement('pre');
-        const code = document.createElement('code');
-        code.className = 'language-python'; // Assume Python, adjust if needed
-        code.textContent = choiceData.text; // Set text content
-
-        pre.appendChild(code);
-        label.appendChild(radio);
-        label.appendChild(pre);
-        choicesAreaEl.appendChild(label);
-        choiceElementsToHighlight.push(code);
-    });
-
-    // --- Highlight all choice code elements *after* they are in the DOM ---
-    if (window.Prism) {
-        choiceElementsToHighlight.forEach(codeElement => {
-            Prism.highlightElement(codeElement);
+    if (funModeToggle) {
+        funModeToggle.addEventListener('change', () => {
+            const nextState = funModeToggle.checked;
+            if (!nextState) {
+                if (!userState.settings.resumePreferences) {
+                    userState.settings.resumePreferences = {
+                        sounds: userState.settings.sounds,
+                        reducedMotion: userState.settings.reducedMotion
+                    };
+                }
+            } else if (userState.settings.resumePreferences) {
+                userState.settings.sounds = !!userState.settings.resumePreferences.sounds;
+                userState.settings.reducedMotion = !!userState.settings.resumePreferences.reducedMotion;
+                userState.settings.resumePreferences = null;
+            }
+            userState.settings.funMode = nextState;
+            applyUserSettings();
+            saveUserState();
         });
     }
+
+    if (soundsToggle) {
+        soundsToggle.addEventListener('change', () => {
+            userState.settings.sounds = soundsToggle.checked;
+            applyUserSettings();
+            saveUserState();
+        });
+    }
+
+    if (reducedMotionToggle) {
+        reducedMotionToggle.addEventListener('change', () => {
+            userState.settings.reducedMotion = reducedMotionToggle.checked;
+            applyUserSettings();
+            saveUserState();
+        });
+    }
+
+    applyUserSettings();
+}
+
+// --- Initialization ---
+function initializeQuiz() {
+    loadProgress();
+    fetch('quiz-data.json')
+        .then(response => {
+            if (!response.ok) {
+                throw new Error('Network response was not ok ' + response.statusText);
+            }
+            return response.json();
+        })
+        .then(data => {
+            quizData = data;
+            // Shuffle questions initially
+            // shuffleArray(quizData);
+            populateQuestionList();
+            displayQuestion(currentQuestionIndex);
+            updateProgressBar();
+            setupTabNavigation();
+            setupReviewTab();
+        })
+        .catch(error => {
+            console.error('Failed to load quiz data:', error);
+            problemStatementEl.textContent = 'Error loading quiz questions. Please check the console.';
+            // Optionally load fallback data or show a user-friendly error
+        });
+}
+
+// --- Progress Management ---
+function saveProgress() {
+    localStorage.setItem('algoQuizProgress', JSON.stringify(quizProgress));
+}
+
+function loadProgress() {
+    const savedProgress = localStorage.getItem('algoQuizProgress');
+    if (savedProgress) {
+        quizProgress = JSON.parse(savedProgress);
+        // Find the first incomplete question to start
+        currentQuestionIndex = quizData.findIndex((_, index) => !quizProgress[index]?.completed);
+        if (currentQuestionIndex === -1) currentQuestionIndex = 0; // If all complete, start from 0
+    } else {
+        quizProgress = {};
+        currentQuestionIndex = 0;
+    }
+}
+
+function resetProgress() {
+    if (confirm('Are you sure you want to reset all your progress?')) {
+        quizProgress = {};
+        localStorage.removeItem('algoQuizProgress');
+        currentQuestionIndex = 0;
+        // Reset UI elements
+        feedbackAreaEl.style.display = 'none';
+        nextButton.style.display = 'none';
+        checkButton.disabled = true; // Disable until an answer is selected
+        checkButton.style.display = 'inline-block';
+        populateQuestionList(); // Update list styling
+        displayQuestion(currentQuestionIndex);
+        updateProgressBar();
+        setupReviewTab(); // Clear review tab
+    }
+}
+
+// --- Tab Navigation ---
+function setupTabNavigation() {
+    tabs.forEach(tab => {
+        tab.addEventListener('click', () => {
+            // Deactivate all tabs and content
+            tabs.forEach(t => t.classList.remove('active'));
+            tabContents.forEach(c => c.classList.remove('active'));
+
+            // Activate the clicked tab and content
+            tab.classList.add('active');
+            const targetContentId = tab.getAttribute('data-tab');
+            const targetContent = document.getElementById(targetContentId);
+            if (targetContent) {
+                targetContent.classList.add('active');
+            }
+
+            // Special handling for review tab update
+            if (targetContentId === 'review') {
+                setupReviewTab();
+            }
+        });
+    });
+}
+
+// --- Question List ---
+function populateQuestionList() {
+    questionsListEl.innerHTML = ''; // Clear existing list
+    quizData.forEach((question, index) => {
+        const listItem = document.createElement('div');
+        listItem.classList.add('question-item');
+        
+        let prefix = ''; // Icon prefix
+        // Mark as completed if applicable
+        if (quizProgress[index]?.completed) {
+            listItem.classList.add('completed');
+            if (quizProgress[index]?.correct === false) {
+                listItem.classList.add('incorrect-answered'); // Add specific class for review styling
+                prefix = '❌ '; // Add cross mark
+            } else {
+                 prefix = '✅ '; // Add check mark
+            }
+        }
+        
+        // Set text content including the prefix
+        listItem.textContent = `${prefix}${index + 1}. ${question.problemTitle}`; // Use problemTitle
+        listItem.dataset.index = index;
+
+        listItem.addEventListener('click', () => {
+            // Switch back to the quiz tab FIRST
+            const quizTabButton = document.querySelector('.tab-button[data-tab="quiz-content"]');
+            if (quizTabButton) {
+                quizTabButton.click();
+            } else {
+                console.error('Quiz tab button not found');
+                // Proceed even if button not found, might still work
+            }
+            
+            // THEN update index and display the question
+            currentQuestionIndex = index; 
+            displayQuestion(currentQuestionIndex); 
+        });
+        questionsListEl.appendChild(listItem);
+    });
+}
+
+// --- Review Tab ---
+function setupReviewTab() {
+    reviewListEl.innerHTML = ''; // Clear previous review items
+    let incorrectCount = 0;
+    let correctCount = 0;
+    let completedCount = 0;
+
+    for (const index in quizProgress) {
+        if (quizProgress[index]?.completed) {
+            completedCount++;
+            if (quizProgress[index]?.correct) {
+                correctCount++;
+            } else {
+                incorrectCount++;
+                const question = quizData[index];
+                if (!question) continue; // Skip if question data missing
+
+                const reviewItem = document.createElement('li');
+                reviewItem.classList.add('review-item', 'incorrect-answered');
+                reviewItem.innerHTML = `
+                    <strong>${parseInt(index) + 1}. ${question.problemTitle}</strong>
+                    <span>Your Answer: Choice ${quizProgress[index].selected !== null ? String.fromCharCode(65 + quizProgress[index].selected) : 'N/A'}</span>
+                    <div class="review-details">
+                        <p><strong>Your Incorrect Choice:</strong></p>
+                        <pre><code class="language-python">${question.choices[quizProgress[index].selected]?.text || 'Not Available'}</code></pre>
+                        <p><strong>Correct Choice (${String.fromCharCode(65 + question.choices.findIndex(c => c.correct))}):</strong></p>
+                        <pre><code class="language-python">${question.choices.find(c => c.correct)?.text || 'Not Available'}</code></pre>
+                        <p><strong>Explanation:</strong></p>
+                        <p>${quizProgress[index].explanation || 'No explanation available.'}</p>
+                    </div>
+                `;
+                reviewListEl.appendChild(reviewItem);
+            }
+        }
+    }
+
+    // Update summary
+    reviewSummaryEl.innerHTML = `
+        <p>Total Questions: ${quizData.length}</p>
+        <p>Completed: ${completedCount}</p>
+        <p>Correct: ${correctCount}</p>
+        <p>Incorrect: ${incorrectCount}</p>
+    `;
+
+    // Re-highlight code in the review tab
+    reviewListEl.querySelectorAll('pre code').forEach((block) => {
+        Prism.highlightElement(block);
+    });
+}
+
+// --- Quiz Display & Interaction ---
+function displayQuestion(index) {
+    if (index >= quizData.length || index < 0) {
+        console.error('Invalid question index:', index);
+        problemStatementEl.textContent = 'End of Quiz or Invalid Question.';
+        codeSkeletonEl.textContent = '';
+        choiceTabsEl.innerHTML = '';
+        choiceDetailsEl.innerHTML = '';
+        checkButton.style.display = 'none';
+        nextButton.style.display = 'none';
+        return;
+    }
+
+    const question = quizData[index];
+    problemStatementEl.innerHTML = question.problemStatement.replace(/\n/g, '<br>'); // Keep line breaks
+    
+    // Update code skeleton content
+    if (codeSkeletonEl) {
+        codeSkeletonEl.textContent = question.codeSkeleton;
+        // Re-highlight skeleton code AFTER setting content
+        Prism.highlightElement(codeSkeletonEl); 
+    } else {
+        console.error("#code-skeleton code element not found");
+    }
+
+    choiceTabsEl.innerHTML = ''; // Clear previous tabs
+    choiceDetailsEl.innerHTML = ''; // Clear previous details
+    choiceDetailsEl.appendChild(choicesPlaceholderEl); // Show placeholder
+    choicesPlaceholderEl.style.display = 'block';
+
+    selectedAnswerIndex = null; // Reset selection
+
+    question.choices.forEach((choice, i) => {
+        // Create Tab Button
+        const tabButton = document.createElement('button');
+        tabButton.classList.add('choice-tab-button');
+        tabButton.textContent = String.fromCharCode(65 + i); // A, B, C...
+        tabButton.dataset.index = i;
+
+        tabButton.addEventListener('click', () => {
+            // Remove selected class from all tabs
+            choiceTabsEl.querySelectorAll('.choice-tab-button').forEach(btn => btn.classList.remove('selected'));
+            // Add selected class to clicked tab
+            tabButton.classList.add('selected');
+            selectedAnswerIndex = i;
+            checkButton.disabled = false;
+
+            // Display choice details
+            choicesPlaceholderEl.style.display = 'none'; // Hide placeholder
+            choiceDetailsEl.innerHTML = ''; // Clear previous details
+            const choicePre = document.createElement('pre');
+            const choiceCode = document.createElement('code');
+            choiceCode.classList.add('language-python'); // Assuming python
+            choiceCode.textContent = choice.text;
+            choicePre.appendChild(choiceCode);
+            choiceDetailsEl.appendChild(choicePre);
+            Prism.highlightElement(choiceCode); // Highlight the new code
+        });
+
+        choiceTabsEl.appendChild(tabButton);
+    });
+
+    // Reset button states
+    feedbackAreaEl.style.display = 'none';
+    feedbackAreaEl.className = ''; // Remove correct/incorrect classes
+    checkButton.style.display = 'inline-block';
+    checkButton.disabled = true; // Disabled until a choice tab is clicked
+    nextButton.style.display = 'none';
+
+    updateProgressBar();
 }
 
 function checkAnswer() {
-    const selectedRadio = document.querySelector('input[name="answer"]:checked');
-    if (!selectedRadio) {
-        feedbackAreaEl.textContent = "Please select an answer.";
-        feedbackAreaEl.className = 'feedback-area incorrect';
-        return;
+    if (selectedAnswerIndex === null) return; // No answer selected
+
+    const question = quizData[currentQuestionIndex];
+    const selectedChoice = question.choices[selectedAnswerIndex];
+    const correctChoiceIndex = question.choices.findIndex(choice => choice.correct);
+    const isCorrect = selectedChoice.correct;
+
+    // Determine explanation to show
+    let explanation = '';
+    if (selectedChoice.explanation) {
+        explanation = selectedChoice.explanation;
+    } else if (isCorrect) {
+        explanation = 'Correct!'; // Default correct message
+    } else {
+        // If incorrect and no specific explanation, try to find the correct one's explanation
+        explanation = question.choices[correctChoiceIndex]?.explanation || 'Incorrect. Review the correct answer.';
     }
 
-    const selectedChoiceIndex = parseInt(selectedRadio.value, 10);
-    const isCorrect = selectedChoiceIndex === correctAnswerIndex;
-
-    // --- Record the result --- 
-    sessionProgress[currentQuestionIndex] = {
-        selected: selectedChoiceIndex,
-        correct: correctAnswerIndex, // Storing this might be useful for review
-        isCorrect: isCorrect
+    // Store progress
+    quizProgress[currentQuestionIndex] = {
+        completed: true,
+        correct: isCorrect,
+        selected: selectedAnswerIndex,
+        explanation: explanation // Store the determined explanation
     };
-    saveSessionProgress(); // Save progress immediately
-    // -------------------------
+    saveProgress();
 
-    const selectedLabel = selectedRadio.closest('label');
+    // Show feedback
+    showFeedback(isCorrect, explanation);
 
-    document.querySelectorAll('input[name="answer"]').forEach(radio => {
-        radio.disabled = true;
+    // Disable choice tabs after checking
+    choiceTabsEl.querySelectorAll('.choice-tab-button').forEach(btn => {
+        btn.disabled = true;
+        btn.style.cursor = 'default';
+        btn.style.opacity = '0.7';
     });
-    checkButton.disabled = true;
+
     checkButton.style.display = 'none';
+    nextButton.style.display = 'inline-block';
 
-    if (isCorrect) { // Use the calculated isCorrect variable
-        feedbackAreaEl.textContent = "Correct!";
-        feedbackAreaEl.className = 'feedback-area correct';
-        if (selectedLabel) {
-            selectedLabel.classList.add('correct-style');
-        }
-    } else {
-        feedbackAreaEl.textContent = "Incorrect.";
-        feedbackAreaEl.className = 'feedback-area incorrect';
-        const correctLabel = document.querySelector(`input[value='${correctAnswerIndex}']`)?.closest('label');
-        if (correctLabel) {
-            correctLabel.classList.add('correct-style');
-        }
-        if (selectedLabel) {
-            selectedLabel.classList.add('incorrect-style');
+    // Update question list styling
+    const listItem = questionsListEl.querySelector(`.question-item[data-index="${currentQuestionIndex}"]`);
+    if (listItem) {
+        listItem.classList.add('completed');
+        if (!isCorrect) {
+            listItem.classList.add('incorrect-answered');
         }
     }
-
-    if (currentQuestionIndex < quizData.length - 1) {
-         nextButton.style.display = 'inline-block';
-    } else {
-         feedbackAreaEl.textContent += " Quiz Finished!";
-    }
-    
-    // Update question list view if it's active to mark as completed
-    if (document.getElementById('question-list-tab').classList.contains('active')) {
-        populateQuestionsList();
-    }
+    updateProgressBar(); // Update progress after answering
 }
 
-/**
- * Populates the list of questions in the 'Question List' tab.
- * Adds click listeners to jump to a specific question.
- */
-function populateQuestionsList() {
-  questionsListEl.innerHTML = '';
+function showFeedback(isCorrect, explanation) {
+    feedbackAreaEl.textContent = explanation;
+    feedbackAreaEl.className = isCorrect ? 'correct' : 'incorrect';
+    feedbackAreaEl.style.display = 'block';
 
-  quizData.forEach((question, index) => {
-    const questionItem = document.createElement('div');
-    questionItem.className = 'question-item';
-    
-    // --- Add visual indicator based on session progress --- 
-    if (sessionProgress[index]) {
-        questionItem.classList.add('answered'); // General answered class
-        if (sessionProgress[index].isCorrect) {
-            questionItem.classList.add('correct-answered'); // Mark correct
-            questionItem.innerHTML = `✅ ${index + 1}. ${question.problemTitle}`;
+    const correctChoiceIndex = quizData[currentQuestionIndex].choices.findIndex(choice => choice.correct);
+
+    // Highlight the correct tab and the selected tab (if different)
+    choiceTabsEl.querySelectorAll('.choice-tab-button').forEach((btn, index) => {
+        if (index === correctChoiceIndex) {
+            btn.classList.add('correct-answer-highlight'); // Style for correct answer
+        }
+        if (index === selectedAnswerIndex && !isCorrect) {
+            btn.classList.add('incorrect-selection-highlight'); // Style for wrong selection
+        }
+    });
+}
+
+
+function nextQuestion() {
+    currentQuestionIndex++;
+    // Find the next *incomplete* question
+    while (currentQuestionIndex < quizData.length && quizProgress[currentQuestionIndex]?.completed) {
+        currentQuestionIndex++;
+    }
+
+    if (currentQuestionIndex >= quizData.length) {
+        // If all questions are completed, go to the first one or show end message
+        // Optionally, check if all are completed and show a final message/review prompt
+        if (Object.keys(quizProgress).length === quizData.length) {
+            alert("Quiz finished! Check the Review tab.");
+            document.querySelector('.tab-button[data-tab="review"]').click();
+            // currentQuestionIndex = 0; // Loop back to start
         } else {
-            questionItem.classList.add('incorrect-answered'); // Mark incorrect
-            questionItem.innerHTML = `❌ ${index + 1}. ${question.problemTitle}`;
+            // If some are skipped, find the first incomplete one from the beginning
+            currentQuestionIndex = quizData.findIndex((_, index) => !quizProgress[index]?.completed);
+             if (currentQuestionIndex === -1) currentQuestionIndex = 0; // Fallback
         }
-    } else {
-        questionItem.textContent = `${index + 1}. ${question.problemTitle}`; // Unanswered
-    }
-    // -------------------------------------------------------
-
-    questionItem.dataset.questionIndex = index;
-    questionsListEl.appendChild(questionItem);
-  });
-
-  // Add event listener to the list container (using event delegation)
-  // Ensure this listener isn't added multiple times if populate is called often
-  // A simple check (might need refinement if populate is called outside switchTab)
-  if (!questionsListEl.dataset.listenerAttached) {
-      questionsListEl.addEventListener('click', (event) => {
-        const questionItemElement = event.target.closest('.question-item');
-        if (questionItemElement) {
-          const index = parseInt(questionItemElement.dataset.questionIndex, 10);
-          console.log("Index:", index); // Keep for debugging if needed
-          if (!isNaN(index)) {
-            jumpToQuestion(index);
-          }
-        }
-      });
-      questionsListEl.dataset.listenerAttached = 'true'; // Mark as attached
-  }
-}
-
-/**
- * Jumps to a specific question in the quiz.
- * @param {number} questionIndex - The index of the question to jump to.
- */
-function jumpToQuestion(questionIndex) {
-  if (questionIndex >= 0 && questionIndex < quizData.length) {
-    currentQuestionIndex = questionIndex;
-    loadQuestion(currentQuestionIndex); // Corrected function call
-    // resetFeedbackAndButtons(); // This is called within loadQuestion now
-    console.log("Switching to quiz tab");
-    switchTab('quiz'); // Switch view back to the quiz
-  } else {
-    console.error('Invalid question index:', questionIndex);
-  }
-}
-
-// --- Helper function to reset feedback and buttons ---
-function resetFeedbackAndButtons() {
-    feedbackAreaEl.textContent = '';
-    feedbackAreaEl.className = 'feedback-area'; // Reset class name
-    checkButton.disabled = false;
-    checkButton.style.display = 'inline-block'; // Use inline-block or block as needed
-    nextButton.style.display = 'none';
-
-    // Re-enable radio buttons and reset styles
-    document.querySelectorAll('#choices-area .choice-label').forEach(label => {
-        label.classList.remove('correct-style', 'incorrect-style');
-        const radio = label.querySelector('input[type="radio"]');
-        if(radio) {
-            radio.disabled = false;
-            radio.checked = false; // Uncheck radios
-        }
-    });
-}
-
-/**
- * Populates the Review Progress tab with summary and details.
- */
-function populateReviewView() {
-    reviewListEl.innerHTML = ''; // Clear previous list
-    reviewSummaryEl.innerHTML = ''; // Clear summary
-
-    const answeredQuestions = Object.keys(sessionProgress);
-    if (answeredQuestions.length === 0) {
-        reviewSummaryEl.textContent = "No questions answered yet in this session.";
-        return;
     }
 
-    let correctCount = 0;
-    answeredQuestions.forEach(qIndexStr => {
-        if (sessionProgress[qIndexStr]?.isCorrect) {
-            correctCount++;
-        }
-    });
-
-    const totalAnswered = answeredQuestions.length;
-    const incorrectCount = totalAnswered - correctCount;
-    const percentage = totalAnswered > 0 ? ((correctCount / totalAnswered) * 100).toFixed(1) : 0;
-
-    reviewSummaryEl.innerHTML = `
-        <p>Total Answered: ${totalAnswered}</p>
-        <p>Correct: ${correctCount}</p>
-        <p>Incorrect: ${incorrectCount}</p>
-        <p>Score: ${percentage}%</p>
-    `;
-
-    // Populate the list with details
-    quizData.forEach((question, index) => {
-        if (sessionProgress[index]) { // Only show answered questions
-            const result = sessionProgress[index];
-            const listItem = document.createElement('li');
-            listItem.className = result.isCorrect ? 'review-item correct-answered' : 'review-item incorrect-answered';
-            
-            // Find the text of the selected and correct choices
-            // Need to find the original choice text based on saved indices
-            // Assumes choices were shuffled! We need to map back or store text.
-            // --- Option 1: Re-find based on index (Simpler for now, less robust if choices change)
-            let selectedChoiceText = "N/A";
-            let correctChoiceText = "N/A";
-            // Note: This assumes the *structure* of choices doesn't change, only order
-            const originalChoices = quizData[index].choices; 
-            if (originalChoices[result.selected]) {
-                selectedChoiceText = originalChoices[result.selected].text.substring(0, 80) + '...'; // Truncate for display
-            }
-             if (originalChoices[result.correct]) {
-                correctChoiceText = originalChoices[result.correct].text.substring(0, 80) + '...'; // Truncate
-            }
-            // --- End Option 1 ---
-            // TODO: A more robust way would be to store the actual text or a stable ID in sessionProgress
-
-            listItem.innerHTML = `
-                <strong>${index + 1}. ${question.problemTitle}</strong> 
-                <span>(${result.isCorrect ? 'Correct' : 'Incorrect'})</span>
-                <div class="review-details">
-                    Your Answer: <pre><code>${selectedChoiceText}</code></pre>
-                    ${!result.isCorrect ? `Correct Answer: <pre><code>${correctChoiceText}</code></pre>` : ''}
-                </div>
-            `;
-            reviewListEl.appendChild(listItem);
-        }
-    });
+    displayQuestion(currentQuestionIndex);
 }
 
-/**
- * Resets the session progress and restarts the quiz.
- */
-function resetProgress() {
-    if (confirm("Are you sure you want to reset your progress? This cannot be undone.")) {
-        sessionProgress = {};
-        localStorage.removeItem(SESSION_STORAGE_KEY);
-        currentQuestionIndex = 0;
-        // Need to re-initialize the quiz state
-        updateProgressBar();
-        loadQuestion(currentQuestionIndex);
-        // Switch back to quiz tab
-        switchTab('quiz');
-        // Clear review view if currently visible
-        reviewListEl.innerHTML = '';
-        reviewSummaryEl.innerHTML = 'Progress reset.';
-        console.log("Session progress reset.");
+// --- Utility Functions ---
+function updateProgressBar() {
+    const completedCount = Object.values(quizProgress).filter(p => p?.completed).length;
+    const totalQuestions = quizData.length;
+    const progressPercent = totalQuestions > 0 ? (completedCount / totalQuestions) * 100 : 0;
+
+    progressTextEl.textContent = `Question ${currentQuestionIndex + 1}/${totalQuestions} (${completedCount} Completed)`;
+    progressBarFillEl.style.width = `${progressPercent}%`;
+}
+
+// Fisher-Yates Shuffle (optional, if needed)
+/*
+function shuffleArray(array) {
+    for (let i = array.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [array[i], array[j]] = [array[j], array[i]];
     }
 }
+*/
 
-// Initialize Quiz and Event Listeners on DOMContentLoaded
+// --- Event Listeners ---
+checkButton.addEventListener('click', checkAnswer);
+nextButton.addEventListener('click', nextQuestion);
+resetProgressButton.addEventListener('click', resetProgress);
+
+// --- Initial Load ---
 document.addEventListener('DOMContentLoaded', () => {
-  fetchQuizData(); // Fetch data when the DOM is ready (this now calls loadSessionProgress indirectly)
-
-  // Tab Navigation Event Listener
-  document.querySelector('.tab-navigation').addEventListener('click', (event) => {
-      if (event.target && event.target.classList.contains('tab-button')) {
-          const tabId = event.target.dataset.tab;
-          switchTab(tabId);
-      }
-  });
-
-  // Check Answer Button Listener
-  if (checkButton) {
-      checkButton.addEventListener('click', checkAnswer);
-  } else {
-      console.error('Check button not found');
-  }
-
-  // Next Question Button Listener
-  if (nextButton) {
-      nextButton.addEventListener('click', () => {
-          // Move to the next question if possible
-          if (currentQuestionIndex < quizData.length - 1) {
-              currentQuestionIndex++;
-              loadQuestion(currentQuestionIndex);
-              // resetFeedbackAndButtons(); // Called within loadQuestion
-              // updateProgressBar(); // Called within loadQuestion
-          } else {
-              // Handle quiz completion (already handled in checkAnswer, potentially)
-              console.log('Attempted to go past the last question.');
-              // alert('Quiz Complete!'); // Maybe show completion state differently
-          }
-      });
-  } else {
-       console.error('Next button not found');
-  }
-
-  // Initial UI setup (optional, if needed before data loads)
-  updateProgressBar(); // Show initial loading state
-
-  // Reset Progress Button Listener
-  if (resetProgressButton) {
-    resetProgressButton.addEventListener('click', resetProgress);
-  } else {
-    console.error('Reset progress button not found');
-  }
-
-}); // End DOMContentLoaded
+    loadUserState();
+    initializeSettingsPanel();
+    initializeQuiz();
+});

--- a/style.css
+++ b/style.css
@@ -3,10 +3,11 @@ body {
     line-height: 1.6;
     padding: 20px;
     background-color: #f4f4f4;
+    font-size: 16px; /* Ensure a reasonable base font size */
 }
 
 .quiz-container {
-    max-width: 800px;
+    max-width: 900px; /* Slightly wider for desktop */
     margin: auto;
     background: #fff;
     padding: 30px;
@@ -18,6 +19,56 @@ h1 {
     text-align: center;
     margin-bottom: 20px;
     color: #333;
+    font-size: 1.8rem; /* Relative size */
+}
+
+.settings-panel {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 12px;
+    margin-bottom: 20px;
+}
+
+.settings-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 14px;
+    background-color: #f5f5f5;
+    border: 1px solid #e5e5e5;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    color: #333;
+    transition: background-color 0.2s ease, border-color 0.2s ease, opacity 0.2s ease;
+    cursor: pointer;
+}
+
+.settings-toggle input[type="checkbox"] {
+    accent-color: #58a700;
+}
+
+.settings-toggle input[type="checkbox"]:disabled {
+    accent-color: #bdbdbd;
+    cursor: not-allowed;
+}
+
+.settings-toggle--disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.settings-toggle:hover {
+    background-color: #eef6e6;
+    border-color: #cfe5bc;
+}
+
+.toggle-title {
+    font-weight: 600;
+}
+
+body.fun-mode-off .settings-panel {
+    opacity: 0.9;
 }
 
 /* --- Progress Bar Styles --- */
@@ -67,20 +118,22 @@ h1 {
     border-radius: 5px;
     border: 1px solid #eee;
     white-space: pre-wrap;
+    font-size: 1rem; /* Ensure statement text is base size */
 }
 
-/* Keep your existing styles for code-skeleton, choices, buttons etc. */
-/* Ensure Prism theme overrides don't clash heavily, adjust if needed */
-#code-skeleton, .choice-label pre code {
+/* Adjust code font size */
+pre, code, #code-skeleton code, .choice-label pre code, #choice-details pre code {
+    font-size: 0.95rem; /* Slightly smaller than base, adjust as needed */
+    font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace; /* Monospace font */
+}
+
+#code-skeleton, .choice-label pre code, #choice-details pre code {
     padding: 15px;
     border-radius: 5px;
     overflow-x: auto;
     white-space: pre;
     display: block;
     margin-top: 5px;
- }
- pre {
-    margin: 0;
  }
 
 .choice-label {
@@ -136,11 +189,14 @@ button:disabled {
 
 
 #feedback-area {
-    margin-top: 20px;
+    margin-top: 0;
+    flex-shrink: 0;
     padding: 15px;
-    border-radius: 8px; /* Match rounding */
+    border-radius: 8px;
     font-weight: bold;
-    text-align: center; /* Center feedback */
+    text-align: center;
+    overflow-y: auto; /* Allow feedback to scroll if very long */
+    max-height: 100px; /* Limit feedback height */
 }
 
 .correct {
@@ -327,23 +383,6 @@ label.incorrect-selection-highlight {
   word-wrap: break-word;
 }
 
-#reset-progress-button {
-    display: block;
-    margin: 20px auto;
-    padding: 10px 20px;
-    background-color: #dc3545; /* Red color for reset */
-    color: white;
-    border: none;
-    border-radius: 5px;
-    cursor: pointer;
-    font-size: 1em;
-    transition: background-color 0.2s ease;
-}
-
-#reset-progress-button:hover {
-    background-color: #c82333;
-}
-
 .choice-label.correct-style { /* Changed selector */
   background-color: #dff0d8; /* Theme green */
   color: white;
@@ -365,3 +404,315 @@ label.incorrect-selection-highlight {
   .choice-label.incorrect-style pre code { /* Changed selector */
     color: white; /* Or another contrasting color if needed */
   }
+
+/* --- New Layout Styles --- */
+/* Apply two-column layout only on larger screens */
+@media (min-width: 768px) {
+  .quiz-layout {
+    display: flex;
+    gap: 20px; /* Space between columns */
+    width: 100%; /* Ensure the container takes full width */
+    box-sizing: border-box; /* Include padding/border in width */
+    flex-grow: 1; /* Allow layout to take available vertical space from #quiz-content */
+    overflow: hidden; /* Prevent layout from overflowing its container */
+  }
+
+  #left-panel {
+    flex: 1; /* Take up available space */
+    min-width: 0; /* Prevent collapsing */
+    /* REMOVE overflow-y: auto; */
+    /* padding-right: 10px; REMOVE padding */
+    display: flex; /* Enable flex column for children */
+    flex-direction: column; 
+    overflow: hidden; /* Prevent left panel itself from scrolling */
+  }
+
+  #left-panel > #problem-statement {
+      flex-shrink: 0; /* Prevent statement from shrinking */
+      margin-bottom: 15px;
+      overflow-y: auto; /* Scroll statement if needed */
+      max-height: 40%; /* Example: Limit statement height */
+      padding-right: 10px; /* Padding for scrollbar */
+  }
+  #left-panel > #code-skeleton {
+      flex-grow: 1; /* Allow skeleton to take remaining space */
+      overflow-y: auto; /* Scroll skeleton if needed */
+      min-height: 100px; /* Ensure it has some minimum height */
+      padding-right: 10px; /* Padding for scrollbar */
+  }
+
+  #right-panel {
+    flex: 1; /* Take up available space */
+    min-width: 0; /* Prevent collapsing */
+    display: flex;
+    flex-direction: column;
+    overflow: hidden; /* Prevent right panel itself from scrolling */
+  }
+
+  /* Adjust button styles now that they are inside right-panel */
+  #right-panel .button-group {
+      display: flex; /* Arrange buttons side-by-side */
+      justify-content: flex-end; /* Align buttons to the right */
+      gap: 10px; /* Space between buttons */
+      padding-top: 15px; /* Space above buttons */
+      flex-shrink: 0; /* Prevent button group from shrinking */
+  }
+
+  #right-panel .button-group button {
+      width: auto; /* Allow button to size naturally */
+      min-width: 120px; /* Set a minimum width */
+      margin-top: 0; /* Remove default top margin */
+      align-self: initial; 
+      margin-left: initial; 
+      margin-right: initial;
+  }
+}
+
+/* Choice Tabs */
+#choice-tabs {
+  display: flex;
+  margin-bottom: 15px;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+  overflow: hidden; /* Contain background */
+  flex-shrink: 0; /* Prevent tabs from shrinking */
+}
+
+.choice-tab-button {
+  flex-grow: 1;
+  padding: 10px 15px;
+  background-color: #f0f0f0;
+  border: none;
+  border-right: 1px solid #ccc;
+  cursor: pointer;
+  text-align: center;
+  font-weight: bold;
+  transition: background-color 0.3s, color 0.3s;
+}
+
+.choice-tab-button:last-child {
+  border-right: none;
+}
+
+.choice-tab-button:hover {
+  background-color: #e0e0e0;
+}
+
+.choice-tab-button.selected {
+  background-color: #58a700; /* Theme green */
+  color: white;
+}
+
+/* Choice Details Area */
+#choice-details {
+  flex-grow: 1; /* Allow this area to fill remaining vertical space */
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 5px;
+  padding: 15px;
+  overflow-y: auto; /* Add scroll ONLY if content is too tall */
+  margin-bottom: 15px; /* Space before feedback/buttons */
+  min-height: 150px; /* Ensure it has some minimum height */
+}
+
+#choice-details pre code {
+  /* Reuse existing styles or add specific ones */
+  padding: 15px;
+  border-radius: 5px;
+  overflow-x: auto;
+  white-space: pre;
+  display: block;
+  margin-top: 5px;
+}
+
+#choices-placeholder {
+    color: #888;
+    font-style: italic;
+    text-align: center;
+    padding: 20px;
+}
+
+/* Hide old choices area structure */
+#choices-area {
+    display: none !important;
+}
+
+/* Make the main quiz content area use flexbox for height control */
+#quiz-content.active {
+    display: flex; /* Changed from block */
+    flex-direction: column;
+    /* Set a fixed height based on viewport, adjust 180px as needed */
+    height: calc(100vh - 180px); 
+    max-height: calc(100vh - 180px);
+    overflow: hidden; /* Prevent outer container scroll */
+}
+
+/* Base styles (Mobile First) */
+
+/* ... existing body, .quiz-container, h1 styles ... */
+
+/* Make the main quiz content area flow naturally on mobile */
+#quiz-content.active {
+    display: block; 
+    height: auto; 
+    max-height: none; 
+}
+
+.quiz-layout {
+    display: block; 
+    width: 100%;
+}
+
+#left-panel, #right-panel {
+    display: block; 
+    width: 100%; 
+    margin-bottom: 20px; 
+    min-height: unset; /* Allow natural height */
+}
+
+#left-panel > #problem-statement,
+#left-panel > #code-skeleton {
+    max-height: none; /* Remove desktop height limits */
+    overflow-y: visible; /* No internal scroll needed by default */
+    padding-right: 0; /* Remove desktop scrollbar padding */
+}
+
+#choice-tabs {
+    display: flex; /* Keep tabs in a row */
+    margin-bottom: 10px;
+}
+
+#choice-details {
+    display: block; /* Show details area */
+    overflow-y: visible; /* No internal scroll needed by default */
+    min-height: initial; /* Reset min-height */
+    margin-bottom: 15px; /* Keep space */
+}
+
+#choices-placeholder {
+    display: block; /* Ensure placeholder is visible if no choice selected */
+}
+
+/* Ensure buttons stack correctly and are visible on mobile */
+.button-group {
+    display: flex;
+    flex-direction: column; 
+    gap: 10px;
+    width: 100%; 
+    margin-top: 25px; /* Increased space above buttons */
+    padding-top: 0; 
+}
+
+.button-group button {
+    width: 100%; 
+    margin-top: 0; 
+}
+
+
+/* --- Existing Progress Bar, Feedback, etc. styles --- */
+
+/* --- Desktop Layout Styles --- */
+/* Apply two-column layout only on larger screens */
+@media (min-width: 768px) {
+    /* Re-apply desktop-specific height */
+    #quiz-content.active {
+        display: flex;
+        flex-direction: column;
+        height: calc(100vh - 180px);
+        max-height: calc(100vh - 180px);
+        overflow: hidden;
+    }
+
+    .quiz-layout {
+        display: flex;
+        gap: 20px;
+        flex-grow: 1;
+        overflow: hidden;
+    }
+
+    #left-panel {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        margin-bottom: 0; /* Remove mobile margin */
+    }
+    
+    #left-panel > #problem-statement {
+        flex-shrink: 0;
+        margin-bottom: 15px;
+        overflow-y: auto;
+        max-height: 40%;
+        padding-right: 10px;
+    }
+    #left-panel > #code-skeleton {
+        flex-grow: 1;
+        overflow-y: auto;
+        min-height: 100px;
+        padding-right: 10px;
+    }
+
+    #right-panel {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        margin-bottom: 0; /* Remove mobile margin */
+    }
+    
+    #choice-tabs {
+         margin-bottom: 15px;
+         flex-shrink: 0;
+    }
+    
+    #choice-details {
+        flex-grow: 1;
+        overflow-y: auto;
+        min-height: 150px;
+    }
+
+    #right-panel .button-group {
+        display: flex;
+        flex-direction: row; 
+        justify-content: flex-end;
+        gap: 10px;
+        padding-top: 15px;
+        flex-shrink: 0;
+        margin-top: auto; 
+    }
+
+    #right-panel .button-group button {
+        width: auto;
+        min-width: 120px;
+        margin-top: 0;
+    }
+    
+    #feedback-area {
+        margin-top: 0;
+        flex-shrink: 0;
+        overflow-y: auto;
+        max-height: 100px;
+    }
+}
+
+/* ... Rest of existing styles ... */
+
+/* RESTORE original styles for Reset Button inside Question List tab */
+#reset-progress-button {
+    display: block;
+    margin: 20px auto;
+    padding: 10px 20px;
+    background-color: #dc3545; /* Red color for reset */
+    color: white;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 1em;
+    transition: background-color 0.2s ease;
+}
+
+#reset-progress-button:hover {
+    background-color: #c82333;
+}


### PR DESCRIPTION
- Add Fun Mode settings panel in index.html (Fun Mode, Sounds, Reduced Motion)
- Persist user preferences (funMode, sounds, reducedMotion) in localStorage
- Load/apply user state on DOMContentLoaded; body classes for modes/states
- Style settings controls and disabled states in style.css
- Seed planning workspace: planning/README.md, feature-breakdown.md, task-backlog.md
- Keep changes isolated; no backend required

Also note:
- prd.md updated earlier with Fun Mode PRD
- No push performed; branch only created locally